### PR TITLE
add initial page for division query, implement division query

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -7,6 +7,7 @@
         </router-link>
         <nuxt-link to="/users">Users</nuxt-link>
         <nuxt-link to="/search">Search</nuxt-link>
+        <nuxt-link to="/analytics">Analytics</nuxt-link>
         <a class="github" href="https://github.com/belinghy/cpsc304" target="_blank" rel="noopener">
           Github
         </a>

--- a/db/InsertAllData.sql
+++ b/db/InsertAllData.sql
@@ -1000,6 +1000,9 @@ INSERT INTO Reserves_Promotion_Item (reservation_id, promotion_id)
 VALUES('123456', 'YKK49');
 
 INSERT INTO Reserves_Promotion_Item (reservation_id, promotion_id)
+VALUES('123456', 'UJN11');
+
+INSERT INTO Reserves_Promotion_Item (reservation_id, promotion_id)
 VALUES('123457', 'ABX22');
 
 INSERT INTO Reserves_Promotion_Item (reservation_id, promotion_id)

--- a/pages/analytics/index.vue
+++ b/pages/analytics/index.vue
@@ -1,0 +1,111 @@
+<template>
+  <section class="analytics">
+    <div class="content">
+      <div class="subsection">
+        <div style="margin: 25px 10px;">
+          <span class="subsection-title" style="vertical-align: middle;">Analytical queries</span>
+        </div>
+        <div style="margin: 25px 10px;">
+          <span class="subsection-title" style="vertical-align: middle;">
+            1. Find the phone numbers of customers who have ordered all promotion items
+          </span>
+          <button v-on:click="division()">Search!</button>
+        </div>
+        <div style="margin: 25px 10px;">
+          <span class="subsection-title" style="vertical-align: middle;">
+            Insert a new promotion ID and item and re-run
+          </span>
+        </div>
+        <div style='margin: 10px 0;'>
+          <span class='landsat_takesoff_flight-flightno'>Promotion ID: </span>
+          <input type='text' v-model='promo_id'></input>
+          <span class='landsat_takesoff_flight-flightno'>Promotion item: </span>
+          <input type='text' v-model='promo_item'></input>
+          <button v-on:click="insertPromoItem()">Insert!</button>
+        </div>
+        <div style='margin: 8px 0;'>
+          <table id='division-results'>
+            <thead>
+              <tr>
+                <th v-for='col in columns'>{{col}}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for='(row, index) in rows'>
+                <td >{{ row.phone_no }}</td>
+                <br>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import axios from '~/plugins/axios'
+
+export default {
+  data () {
+    return {
+      rows: [],
+      columns: [],
+      promo_id: '',
+      promo_item: ''
+    }
+  },
+
+  methods: {
+    division () {
+      let self = this
+
+      axios.get('/api/analytics/divide')
+        .then((res) => {
+          if (res.data.length === 0) {
+            alert('No results found!')
+          }
+          self.rows = res.data
+          self.columns = ['Phone no.']
+        })
+        .catch((e) => {
+          alert(e)
+        })
+    },
+
+    insertPromoItem () {
+      let self = this
+
+      if (self.promo_id && self.promo_item) {
+        axios.post('/api/analytics/newpromo', {
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          data: {
+            promotion_id: self.promo_id,
+            promotion_item: self.promo_item
+          }
+        })
+          .then((res) => {
+            alert(res.data)
+          })
+          .catch((e) => {
+            alert(e.response.data)
+          })
+      } else {
+        alert('Error: please input both a valid promotion ID and item.')
+      }
+    }
+  },
+
+  head () {
+    return {
+      title: 'Analytics'
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/server/api/analytics.js
+++ b/server/api/analytics.js
@@ -1,0 +1,61 @@
+import { Router } from 'express'
+var connection = require('../configs/sequelize')
+const bodyParser = require('body-parser')
+
+const router = Router()
+
+/* GET phone numbers of customers who have ordered all promotion items */
+router.get('/analytics/divide', function (req, res, next) {
+  console.log('Division query...');
+  const query = 'SELECT C.phone_no ' +
+      'FROM Customer C ' +
+      'WHERE C.email IN ' +
+      '(SELECT R.email ' +
+      'FROM Reserves_Occupies_Reservation R ' +
+      'WHERE NOT EXISTS ' +
+      '(SELECT P.promotion_id ' +
+      'FROM Promotion_Item P ' +
+      'EXCEPT ' +
+      'SELECT I.promotion_id ' +
+      'FROM Reserves_Promotion_Item I ' +
+      'WHERE I.reservation_id = R.reservation_id));';
+
+  connection.query(query, {
+    type: connection.QueryTypes.SELECT
+  })
+    .then((result) => {
+      console.log(result);
+      res.json(result);
+    })
+    .catch((e) => {
+      console.log(e);
+      res.status(400).send(e.message);
+    })
+})
+
+/* INSERT new promotion item */
+router.post('/analytics/newpromo', bodyParser.json(), function (req, res, next) {
+  console.log('Inserting new promo item...');
+  const promotion_id = req.body.data.promotion_id;
+  const promotion_item = req.body.data.promotion_item;
+  const query = 'INSERT INTO promotion_item(promotion_id, promotion_item) ' +
+      'VALUES (:promotion_id, :promotion_item);';
+
+  connection.query(query, {
+    type: connection.QueryTypes.INSERT,
+    replacements: {
+      promotion_id: promotion_id,
+      promotion_item: promotion_item
+    }
+  })
+    .then((result) => {
+      console.log(result);
+      res.status(200).send('Promotion item successfully added.');
+    })
+    .catch((e) => {
+      console.log(e);
+      res.status(400).send('Failed to add promotion item. Please try again.');
+    })
+})
+
+export default router

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import users from './users'
 import searchqueries from './searchqueries'
 import book from './book'
+import analytics from './analytics'
 
 const router = Router()
 
@@ -10,4 +11,5 @@ const router = Router()
 router.use(users)
 router.use(searchqueries)
 router.use(book)
+router.use(analytics)
 export default router


### PR DESCRIPTION
1. Added a new page for 'analytical' (i.e. requirements fulfilling) queries.
2. Added another tuple to have more than one result during the initial query.
3. Added ability for user to input new promotion item and re-run the query.

@brian618 you can expand on this page by adding more to `index.vue` and `analytics.js`, I think all you have to do is just implement the front and backend for the nested aggregation queries.  